### PR TITLE
Fix behavior for rails 5.2

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -210,7 +210,7 @@ module ActionView
               options[:include_blank] ||= true unless options[:prompt]
             end
 
-            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value : value(object))
+            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value() : value(object))
             priority_regions = options[:priority] || []
             opts = add_options(region_options_for_select(parent_region.subregions, value, 
                                                         :priority => priority_regions), 


### PR DESCRIPTION
hello!
your fix wasn't correct. I connected this fix to my project and found that value from an object always nil.
ruby doesn't call method value it takes nil value from variable. 