### PR TITLE
Rails 6

### DIFF
--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -210,7 +210,7 @@ module ActionView
               options[:include_blank] ||= true unless options[:prompt]
             end
 
-            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value : value(object))
+            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value() : value(object))
             priority_regions = options[:priority] || []
             opts = add_options(region_options_for_select(parent_region.subregions, value, 
                                                         :priority => priority_regions), 


### PR DESCRIPTION
@abrom
so I have just written the [TestApplication](https://github.com/yuri-zubov/TestApplication).
And connect your gem for testing. Please look at this [commit](https://github.com/yuri-zubov/TestApplication/commit/b4861eeef4fb589d83bea5e7adf72e53eb7deae0).
I try to initialize select by default value - RU
```ruby
<%= fields_for :test, OpenStruct.new(country: 'RU') do |f| %>
  <%= f.country_select :country %>
<% end %>
```
And see 
![image](https://user-images.githubusercontent.com/2146069/67845487-9aff9380-fb10-11e9-93be-4083370d0366.png)
if I change to my version (gem 'carmen-rails', github: 'yuri-zubov/carmen-rails', branch: 'rails-6') in Gemfile I will see 
![image](https://user-images.githubusercontent.com/2146069/67845614-d5693080-fb10-11e9-895c-411a844dfd15.png)
Please apply my fix 

p.s. I describe the behavior of ruby in this [issue](https://github.com/carmen-ruby/carmen-rails/issues/60#issuecomment-536271481)