### PR TITLE
Support Rails 6

### DIFF
--- a/carmen-rails.gemspec
+++ b/carmen-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails"
-  s.add_dependency "carmen", "~> 1.0.0"
+  s.add_dependency "carmen", "~> 1.0"
 
   s.add_development_dependency "minitest"
 end

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -210,7 +210,7 @@ module ActionView
               options[:include_blank] ||= true unless options[:prompt]
             end
 
-            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value : value(object))
+            value = options[:selected] ? options[:selected] : (method(:value).arity.zero? ? value() : value(object))
             priority_regions = options[:priority] || []
             opts = add_options(region_options_for_select(parent_region.subregions, value, 
                                                         :priority => priority_regions), 

--- a/lib/carmen/rails/action_view/form_helper.rb
+++ b/lib/carmen/rails/action_view/form_helper.rb
@@ -197,7 +197,7 @@ module ActionView
       end
     end
 
-    if [4, 5].include? Rails::VERSION::MAJOR
+    if [4, 5, 6].include? Rails::VERSION::MAJOR
       module Tags
         class Base
           def to_region_select_tag(parent_region, options = {}, html_options = {})
@@ -205,7 +205,7 @@ module ActionView
             add_default_name_and_id(html_options)
 
             if (Rails::VERSION::MAJOR == 4 && !select_not_required?(html_options)) ||
-               (Rails::VERSION::MAJOR == 5 && placeholder_required?(html_options))
+               ([5, 6].include?(Rails::VERSION::MAJOR) && placeholder_required?(html_options))
               raise ArgumentError, "include_blank cannot be false for a required field." if options[:include_blank] == false
               options[:include_blank] ||= true unless options[:prompt]
             end


### PR DESCRIPTION
Update guard for `to_region_select_tag` to support Rails 6

Also includes:
* bug fix to handle zero arity value method [@yuri-zubov]
* relax carmen gem dependency [@yuri-zubov]